### PR TITLE
Support Python 2.7, fixes #3

### DIFF
--- a/decorating/animation.py
+++ b/decorating/animation.py
@@ -147,11 +147,12 @@ def _spinner(control):
     iterator = zip(cycle(NBRAILY), cycle(asciiart.VPULSE))
     for i, (start, end) in enumerate(iterator):
         padding = control.fpadding(i + control.bias)
-        info = dict(message=colorize_no_reset(control.message, 'red'),
-                    padding=colorize_no_reset(padding, 'blue'),
-                    start=colorize_no_reset(start, 'cyan'),
-                    end=color.colorize(end, 'cyan'))
-        message = '\r' + template.format(**info)
+        message = '\r' + template.format(
+            message=colorize_no_reset(control.message, 'red'),
+            padding=colorize_no_reset(padding, 'blue'),
+            start=colorize_no_reset(start, 'cyan'),
+            end=color.colorize(end, 'cyan')
+        )
         with control.stream.lock:
             control.stream.write(message)
         if not control.running:

--- a/decorating/animation.py
+++ b/decorating/animation.py
@@ -40,17 +40,15 @@
 
 
 """
-
+from __future__ import unicode_literals
 import signal
 import sys
 import threading
 from math import sin
 from functools import partial
 from itertools import cycle
-from decorating import decorator
-from decorating import color
-from decorating import stream
-from decorating import asciiart
+from . import decorator, color, stream, asciiart
+from .general import zip
 
 
 # THIS IS A LOL ZONE
@@ -98,7 +96,7 @@ class AnimationController(object):
     messages = []
 
 
-def space_wave(λ, char=asciiart.WAVE, amplitude=12, frequency=0.1):
+def space_wave(phase, char=asciiart.WAVE, amplitude=12, frequency=0.1):
     """
     Function: space_wave
     Summary: This function is used to generate a wave-like padding
@@ -126,7 +124,7 @@ def space_wave(λ, char=asciiart.WAVE, amplitude=12, frequency=0.1):
               █
 
     Attributes:
-        @param (λ): your positive variable, can be a int or float
+        @param (phase): your positive variable, can be a int or float
         @param (char) default='█': the char to construct the space_wave
         @param (amplitude) default=10: a float/int number to describe
                                        how long is the space_wave max
@@ -135,7 +133,7 @@ def space_wave(λ, char=asciiart.WAVE, amplitude=12, frequency=0.1):
     """
     wave = cycle(char)
     return ''.join((next(wave) for x in range
-                    (int((amplitude + 1) * abs(sin(frequency * (λ)))))))
+                    (int((amplitude + 1) * abs(sin(frequency * (phase)))))))
 
 
 def _spinner(control):
@@ -153,7 +151,7 @@ def _spinner(control):
                     padding=colorize_no_reset(padding, 'blue'),
                     start=colorize_no_reset(start, 'cyan'),
                     end=color.colorize(end, 'cyan'))
-        message = '\r' + template.format_map(info)
+        message = '\r' + template.format(**info)
         with control.stream.lock:
             control.stream.write(message)
         if not control.running:

--- a/decorating/asciiart.py
+++ b/decorating/asciiart.py
@@ -50,6 +50,7 @@
 
     LOOOOOOOOOOOOOL ART
 """
+from __future__ import unicode_literals
 
 # START
 #     /\O    |    _O    |      O

--- a/decorating/base.py
+++ b/decorating/base.py
@@ -20,12 +20,12 @@
     * Decorator: Abstract Class for creating new decorators
 
 """
-
+from __future__ import unicode_literals
 from abc import abstractmethod, ABCMeta
+from .general import with_metaclass
 
 
-class Stream(metaclass=ABCMeta):
-
+class Stream(with_metaclass(ABCMeta)):
     """A base class whose is specify a Stream is
 
     We need at least a stream on init and a
@@ -43,8 +43,7 @@ class Stream(metaclass=ABCMeta):
         pass
 
 
-class DecoratorManager(metaclass=ABCMeta):
-
+class DecoratorManager(with_metaclass(ABCMeta)):
     """Decorator-Context-Manager base class to keep easy creating more decorators
 
     argument: can be empty or a callable object (function or class)

--- a/decorating/color.py
+++ b/decorating/color.py
@@ -14,7 +14,7 @@
     If the exection is not attatched in any tty,
     so colored is disabled
 """
-
+from __future__ import unicode_literals
 
 import sys
 
@@ -56,8 +56,8 @@ def colorize(printable, color, style='normal', autoreset=True):
     if color not in COLOR_MAP:
         raise RuntimeError('invalid color set, no {}'.format(color))
 
-    return '{color}{printable}{reset}'.format_map({
-        'printable': printable,
-        'color': COLOR_MAP[color].format(style=STYLE_MAP[style]),
-        'reset': COLOR_MAP['reset'] if autoreset else '',
-    })
+    return '{color}{printable}{reset}'.format(
+        printable=printable,
+        color=COLOR_MAP[color].format(style=STYLE_MAP[style]),
+        reset=COLOR_MAP['reset'] if autoreset else ''
+    )

--- a/decorating/debugging.py
+++ b/decorating/debugging.py
@@ -11,6 +11,7 @@
     An collection of usefull decorators for debug
     and time evaluation of functions flow
 """
+from __future__ import unicode_literals
 
 from functools import wraps
 from time import time

--- a/decorating/decorator.py
+++ b/decorating/decorator.py
@@ -17,10 +17,11 @@
     * Decorator: A base class for creating new decorators
 
 """
+from __future__ import unicode_literals
 
 from functools import wraps
 from warnings import warn
-from decorating.base import DecoratorManager
+from .base import DecoratorManager
 
 
 # A UNINTENDED LOL-ZONE: SORRY FOR THIS
@@ -59,7 +60,7 @@ class Decorator(DecoratorManager):
             self.logoff()
 
         def login(self):
-            print('Welcome to the Wired, {user}!'.format_map(vars(self)))
+            print('Welcome to the Wired, {user}!'.format(**vars(self)))
 
         def logoff(self):
             print('Close this world, open the next!'.)
@@ -116,7 +117,7 @@ class Decorator(DecoratorManager):
         instance = cls.recreate(*args, **kwargs)
         cls.instances.append(instance)
         if any(args) and callable(args[0]):  # pass a function/class
-            return super(cls, cls)._over_wrapper(instance, args[0])
+            return instance._over_wrapper(args[0])
 
         return instance
 

--- a/decorating/decorator.py
+++ b/decorating/decorator.py
@@ -60,7 +60,7 @@ class Decorator(DecoratorManager):
             self.logoff()
 
         def login(self):
-            print('Welcome to the Wired, {user}!'.format(**vars(self)))
+            print('Welcome to the Wired, {user}!'.format(user=self.user))
 
         def logoff(self):
             print('Close this world, open the next!'.)

--- a/decorating/general.py
+++ b/decorating/general.py
@@ -7,6 +7,8 @@
 #     @author: Manoel Vilela
 #      @email: manoel_vilela@engineer.com
 #
+# pylint: disable=redefined-builtin
+# pylint: disable=invalid-name
 
 """
     An collection of usefull decorators for debug
@@ -15,6 +17,34 @@
 
 # stdlib
 from functools import wraps
+import sys
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+
+if PY2:
+    from itertools import izip
+    zip = izip
+else:
+    zip = zip
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+
+    # Copied from `six' library.
+    # Copyright (c) 2010-2015 Benjamin Peterson
+    # License: MIT
+
+    class metaclass(meta):
+        """Dummy metaclass"""
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+    return type.__new__(metaclass, 'temporary_class', (), {})
 
 
 def cache(function):

--- a/decorating/general.py
+++ b/decorating/general.py
@@ -23,10 +23,10 @@ PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 
-if PY2:
+if PY2:  # pragma: no cover
     from itertools import izip
     zip = izip
-else:
+else:  # pragma: no cover
     zip = zip
 
 

--- a/decorating/stream.py
+++ b/decorating/stream.py
@@ -146,7 +146,7 @@ class Writting(Unbuffered):
         self.delay = delay
 
     def write(self, message, flush=True):
-        if isinstance(message, bytes):
+        if isinstance(message, bytes):  # pragma: no cover
             message = message.decode('utf-8')
 
         """A Writting like write method, delayed at each char"""

--- a/decorating/stream.py
+++ b/decorating/stream.py
@@ -20,6 +20,7 @@
     * Writing(Unbuffered) :: stream for writing delayed typing
 
 """
+from __future__ import unicode_literals
 
 import time
 import re
@@ -38,7 +39,7 @@ class Unbuffered(Stream):
     lock = Lock()
 
     def __init__(self, stream):
-        super().__init__(stream)
+        super(Unbuffered, self).__init__(stream)
         self.stream = stream
 
     def write(self, message, flush=True):
@@ -122,7 +123,7 @@ class Clean(Unbuffered):
         # the stderr
         with self.lock:
             self.paralell_stream.erase()
-            super().write(message, flush)
+            super(Clean, self).write(message, flush)
             # for some reason I need to put a '\n' here to correct
             # print of the message, if don't put this, the print internal
             # during the animation is not printed.
@@ -145,7 +146,10 @@ class Writting(Unbuffered):
         self.delay = delay
 
     def write(self, message, flush=True):
+        if isinstance(message, bytes):
+            message = message.decode('utf-8')
+
         """A Writting like write method, delayed at each char"""
         for char in message:
             time.sleep(self.delay * (4 if char == '\n' else 1))
-            super().write(char, flush)
+            super(Writting, self).write(char, flush)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -40,12 +40,12 @@ class Wired(decorator.Decorator):
 
     def login(self):
         """Login in the wired with the default user"""
-        print('Welcome to the Wired, {user}!'.format(**vars(self)))
+        print('Welcome to the Wired, {user}!'.format(user=self.user))
 
     def logoff(self):
         """Exits of this world, open the next"""
         print('Close this world, open the next!')
-        print('Goodbye, {user}...'.format(**vars(self)))
+        print('Goodbye, {user}...'.format(user=self.user))
         del self.user
 
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -40,12 +40,12 @@ class Wired(decorator.Decorator):
 
     def login(self):
         """Login in the wired with the default user"""
-        print('Welcome to the Wired, {user}!'.format_map(vars(self)))
+        print('Welcome to the Wired, {user}!'.format(**vars(self)))
 
     def logoff(self):
         """Exits of this world, open the next"""
         print('Close this world, open the next!')
-        print('Goodbye, {user}...'.format_map(vars(self)))
+        print('Goodbye, {user}...'.format(**vars(self)))
         del self.user
 
 


### PR DESCRIPTION
* Explicit unicode handling (unicode_literals, decode string coming to Writting stream)
* Add arguments to super() (required in py2)
* Add with_metaclass() for universal metaclass support
* Redefine zip with its lazy version for py2
* .format_map(x) -> .format(**x)
* Rename λ argument in space_wave() (not supported in py2)
* Convert absolute imports to relative ones
* Call _over_wrapper directly from instance