### PR TITLE
Update travis matrix python version to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
-python:
+python: 
+  - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
-  - "3.2"
+  - "2.7"
 
 sudo: true
 


### PR DESCRIPTION
As described on readme, the current python version supported are:
- 2.7
- 3.4
- 3.5
- 3.6

Maybe 3.2 and 3.3 will still works, but these versions will end support in soon by PSF (or already ended).