### PR TITLE
Implement enabled property on decorating.animation

### DIFF
--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -94,6 +94,15 @@ class TestAnimatedDecorator(unittest.TestCase):
         for level in (level1, level2):
             self.assertEqual(level, self.args, 'need returns the same I/O')
 
+    def test6(self):
+        """Try disable the animation decorated"""
+        print("Testing the enabled/disabled o animated")
+        animated.enabled = False
+        print("animated.enabled = False")
+        self.test4()
+        print("animated.enabled = True")
+        animated.enabled = True
+        self.test5()
 
 class TestWritingDecorator(unittest.TestCase):
 


### PR DESCRIPTION
That way we can enable/disable this feature by:

```python
decorating.animated.enabled = False # disabled
decorating.animated.enabled = True # enable again
```
Let me be clear: this feature doesn't handle well when this
requirement is made concurrently with a already running animation,
this will crash the application!

Maybe I can do a better thing later...