### PR TITLE
Update CHANGELOG, bump version and fix monitor_stdout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,50 +1,55 @@
 - v0.1-alpha
- * add a animated decorator for slow functions
+  * add a animated decorator for slow functions
 - v0.1.1-alpha
- * add optional argument for decorator animated, more descriptive messages
+  * add optional argument for decorator animated, more descriptive messages
 - v0.2-beta
- * support context manager for decorator @animated
- * add basics decorators: cache, count_time, debug, counter and
- * handle sigint signal when user send ctrl+c (stop thread and animation) for animated
- * for the complex animated decorator, use a class instead a simple function
- * refactoring the _spinner function for more clearness
- * added tests for the general.py, the basic decorators
+  * support context manager for decorator @animated
+  * add basics decorators: cache, count_time, debug, counter and
+  * handle sigint signal when user send ctrl+c (stop thread and animation) for animated
+  * for the complex animated decorator, use a class instead a simple function
+  * refactoring the _spinner function for more clearness
+  * added tests for the general.py, the basic decorators
 - v0.2.1-beta
- * use animated as class instead a function wrapper (equal to AnimatedDecorator)
- * fixed tests for count_time decorator, use sleep to avoid time almost 0
- * remove requirements-dev because is useless and the build was breaking with this
+  * use animated as class instead a function wrapper (equal to AnimatedDecorator)
+  * fixed tests for count_time decorator, use sleep to avoid time almost 0
+  * remove requirements-dev because is useless and the build was breaking with this
 - v0.3
- * closes #2: fix usage of function without args
- * add support for nested context managers
- * add inital tests for animated decorator, whose will be more hard to break the things
- * correct setup of CI with coverage using codecov (96% now!)
- * fix problem with logging in animated.py to not progagate the logging when is desactivated (affects ryukinix/mal)
- * in nested @animated executions, correct handle animation context
+  * closes #2: fix usage of function without args
+  * add support for nested context managers
+  * add inital tests for animated decorator, whose will be more hard to break the things
+  * correct setup of CI with coverage using codecov (96% now!)
+  * fix problem with logging in animated.py to not progagate the logging when is desactivated (affects ryukinix/mal)
+  * in nested @animated executions, correct handle animation context
 - v0.4
- * general refactoring of lib on a better idiomatic way
- * added more asciiarts on asciiart.py
- * added the awesome @writing decorator
- * wrote the docstrings for all functions and modules (in a simple way, BTW)
- * added stream.py as colection of streams
- * added a base class for Decorator, useful for new decorators
- * split debugging decorators (debug, counter, count_time) on debugging.py
- * fix the problem of double-lines! beauty use of @animated decorator without pain of internal prints
- * added the decorator base class
- * added the @writing decorator on animation.py
- * added new tests from  hell: color, decorator and review of debugging.
- * added .coveragerc in the repostiory based on you own specification.
+  * general refactoring of lib on a better idiomatic way
+  * added more asciiarts on asciiart.py
+  * added the awesome @writing decorator
+  * wrote the docstrings for all functions and modules (in a simple way, BTW)
+  * added stream.py as colection of streams
+  * added a base class for Decorator, useful for new decorators
+  * split debugging decorators (debug, counter, count_time) on debugging.py
+  * fix the problem of double-lines! beauty use of @animated decorator without pain of internal prints
+  * added the decorator base class
+  * added the @writing decorator on animation.py
+  * added new tests from  hell: color, decorator and review of debugging.
+  * added .coveragerc in the repostiory based on you own specification.
 - v0.5
- * add autoreset param to colorize for win32 plataform
- * add fill with spaces & write backspaces methods on stream.Animation
- * refactored animation.space_wave function, we can pass now a sequence of frames
- * fixed misspeling on LOL-zone of decorating.decorator
- * updated all header of files based a new pattern
+  * add autoreset param to colorize for win32 plataform
+  * add fill with spaces & write backspaces methods on stream.Animation
+  * refactored animation.space_wave function, we can pass now a sequence of frames
+  * fixed misspeling on LOL-zone of decorating.decorator
+  * updated all header of files based a new pattern
 - v0.5.1
- * fixed bug for keyword arguments on decorating.debugging.debug
- * add more tests for debug decorator
- * simplification of code on base.DecoratorManager & decorator.Decorator
+  * fixed bug for keyword arguments on decorating.debugging.debug
+  * add more tests for debug decorator
+  * simplification of code on base.DecoratorManager & decorator.Decorator
 - v0.5.2
- * use ANSI escape codes to erase lines, fix weird inverse behavior in some terminals
+   * use ANSI escape codes to erase lines, fix weird inverse behavior in some terminals
 - v0.6
- * add support for Python2.7
- * add proper docs using sphinx on decorating.readthedocs.io
+  * add support for Python2.7
+  * add proper docs using sphinx on decorating.readthedocs.io
+- v0.6.1
+  * add support for disable/enable decorating.animated
+  * add support for customize spinners and colors of decorating.animated
+  * implement the decorating.monitor_stdout decorator
+  * fix tests about __main__.py function

--- a/decorating/__init__.py
+++ b/decorating/__init__.py
@@ -25,7 +25,7 @@ from decorating.debugging import count_time, counter, debug
 from decorating.general import cache
 from decorating.monitor import monitor_stdout
 
-__version__ = '0.6'
+__version__ = '0.6.1'
 __author__ = 'Manoel Vilela'
 __email__ = 'manoel_vilela@engineer.com'
 __url__ = 'https://github.com/ryukinix/decorating'

--- a/decorating/__init__.py
+++ b/decorating/__init__.py
@@ -11,7 +11,7 @@
 """
     DECORATING: A MODULE OF DECORATORS FROM HELL
 
-    You have that collection of decorators:
+    You have a collection of decorators, like thesexg:
 
     * animated: create animations on terminal until the result's returns
     * cache: returns without reprocess if the give input was already processed
@@ -23,6 +23,7 @@
 from decorating.animation import animated, writing
 from decorating.debugging import count_time, counter, debug
 from decorating.general import cache
+from decorating.monitor import monitor_stdout
 
 __version__ = '0.6'
 __author__ = 'Manoel Vilela'
@@ -36,5 +37,6 @@ __all__ = [
     'counter',
     'debug',
     'count_time',
-    'writing'
+    'writing',
+    'monitor_stdout'
 ]


### PR DESCRIPTION
CHANGELOG updated for 0.6.1 version, using new version
of decorating on `decorating/__init__.py` and as well
added the monitor_stdout to the `__init__.py`  for easily
access.