### PR TITLE
Improving coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,4 +7,14 @@ exclude_lines =
     if __name__ == .__main__.:
     unittest.main()
     pass
-    def __getattr__(self, attr): 
+    def __getattr__(self, attr):
+
+[run]
+omit =
+    # omit anything in a .local directory anywhere
+    */.local/*
+    # omit everything in /usr
+    /usr/*
+    # omit this single file
+    utils/tirefire.py
+    setup.py

--- a/decorating/monitor.py
+++ b/decorating/monitor.py
@@ -38,12 +38,23 @@ class MonitorStdout(Decorator):
     def stop(self):
         sys.stdout = sys.__stdout__
 
+    def clear(self):
+        self.data = []
+
+    @property
+    def data(self):
+        return self.stream.data
+
+    @data.setter
+    def data(self, data):
+        self.stream.data = data
+
 
 monitor_stdout = MonitorStdout()
 
 
-def test():
+def test():  # pragma: no cover
     with monitor_stdout:
         print('test')
 
-    print(monitor_stdout.stream.data)
+    print(monitor_stdout.data)

--- a/decorating/monitor.py
+++ b/decorating/monitor.py
@@ -49,6 +49,13 @@ class MonitorStdout(Decorator):
     def data(self, data):
         self.stream.data = data
 
+    @classmethod
+    def __call__(cls, func):
+        import warnings
+        warnings.warn(("MonitorStdout doesn't works as decorator. "
+                       "Use it as contextmanager by 'with' syntax instead"))
+        return func
+
 
 monitor_stdout = MonitorStdout()
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -69,10 +69,10 @@ class TestWiredDecorator(unittest.TestCase):
 
     def test_deco_layer1(self):
         """Test decorator with basic usage"""
-        with writing(0.1):
+        with writing(0.01):
             @self.wired('Chisa')
             def _knights():
-                with writing(0.3):
+                with writing(0.03):
                     print('suiciding...')
 
             _knights()
@@ -96,7 +96,7 @@ class TestWiredDecorator(unittest.TestCase):
             print("λ- (open-world 'next-life)")
 
         with self.wired("Lerax"):
-            with writing(0.1):
+            with writing(0.01):
                 print("I don't ever exists")
                 print("But I'm exists.")
                 print("hacking... hacking...")

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#    Copyright © Manoel Vilela 2017
+#
+#    @project: Decorating
+#     @author: Manoel Vilela
+#      @email: manoel_vilela@engineer.com
+#
+
+"""
+    These tests cover the basic usage of the decorator monitor_stdout
+
+"""
+
+import unittest
+from decorating import monitor_stdout
+
+
+class TestMonitorStdout(unittest.TestCase):
+
+    def test1(self):
+        """Test using a context manager"""
+        test = "Cancer"
+        expected = ["Cancer", "\n"]
+        with monitor_stdout:
+            print(test)
+        self.assertListEqual(monitor_stdout.data, expected)
+
+    # TODO: fix this test!
+    # Description: this crash the decorating.decorator.Decorator.__call__
+    # procedure! Why???
+    # def test2(self):
+    #     """Test using a function decorated"""
+    #     monitor_stdout.clear()
+    #     test = "This!"
+    #     expected = ["This", "\n"]
+
+    #     @monitor_stdout()
+    #     def test():
+    #         print(test)
+
+    #     test()
+    #     self.assertListEqual(monitor_stdout.data, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Changes:

38a81ef (Manoel Vilela, 2 minutes ago)
   Add a warning about the malfunction of MonitorStdout

   Because some weird reason MonitorStdout just doesn't works as decorator,
   but works pretty well as contextmanager. The funny part is that another
   classes inherited by decorating.decorator.Decorator works well as
   @animated, @writing and even the test-only purpose defined @wired on
   test_decorator.py.

   THIS IS COMPLETELY WEIRD!

2789b25 (Manoel Vilela, 13 minutes ago)
   Add new test for the decorator MonitorStdout

   This decorator doesn't works quite well as decorator... funny! But it works
   as a context manager, I'm adding this because I want, but this shit doesn't
   works properly...

   Maybe I should at least remove from the __init__.py

41998f4 (Manoel Vilela, 34 minutes ago)
   Add clear() method and data property for monitor_stdout

   This should "erase" the stream.data by just creating a new list.

8cb7638 (Manoel Vilela, 35 minutes ago)
   Reduce time of tests on tests/test_decorator.py

   That delay times is just too high. Keeping more lower.

46e9d66 (Manoel Vilela, 36 minutes ago)
   Add more rules on .coveragerc: ignore some files

   We need ignore setup.py because doesn't makes sense coverage that.